### PR TITLE
Integration tests: opt-in guard, version stamps, and auto-cleanup

### DIFF
--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -1,5 +1,11 @@
-# Integration tests — require live Gmail auth
-# Run locally with devtools::test(), skipped in CI
+# Integration tests — require live Gmail auth + explicit opt-in
+# Run with: MC_RUN_INTEGRATION=true devtools::test(filter = "integration")
+# Test emails are trashed automatically after the run.
+
+skip_if_not(
+  identical(Sys.getenv("MC_RUN_INTEGRATION"), "true"),
+  "Set MC_RUN_INTEGRATION=true to run integration tests"
+)
 
 skip_if_not(
   tryCatch({
@@ -9,19 +15,43 @@ skip_if_not(
   "Gmail auth not available"
 )
 
+# Simple searchable tag (no special chars — Gmail search chokes on brackets/pipes)
 test_tag <- format(Sys.time(), "mc-test-%Y%m%d-%H%M%S")
+
+# Metadata for email body — human-readable traceability
+test_meta <- sprintf(
+  "mc %s | R %s | %s | %s",
+  as.character(utils::packageVersion("mc")),
+  paste(R.version$major, R.version$minor, sep = "."),
+  R.version$os,
+  format(Sys.time(), "%Y-%m-%d %H:%M:%S")
+)
+
 env <- new.env(parent = emptyenv())
+
+# Trash all test messages after the run (sent-to-self creates duplicate IDs)
+withr::defer({
+  Sys.sleep(5)
+  for (label in c("", " in:sent", " in:drafts", " in:inbox")) {
+    results <- gmailr::gm_messages(
+      search = paste0("subject:", test_tag, label),
+      num_results = 20
+    )
+    for (id in gmailr::gm_id(results)) {
+      tryCatch(gmailr::gm_trash_message(id), error = function(e) NULL)
+    }
+  }
+}, envir = parent.frame())
 
 test_that("mc_send creates a draft", {
   mc_send(
-    html = paste0("<p>Integration test: ", test_tag, "</p>"),
+    html = paste0("<p>Integration test: ", test_tag, "</p><pre>", test_meta, "</pre>"),
     to = "al@newgraphenvironment.com",
     subject = test_tag,
     sig = FALSE
   )
 
   # Give Gmail a moment to index
-
   Sys.sleep(3)
 
   # Search for the draft by subject
@@ -35,7 +65,7 @@ test_that("mc_send creates a draft", {
 
 test_that("mc_send sends to self", {
   mc_send(
-    html = paste0("<p>Sent test: ", test_tag, "</p>"),
+    html = paste0("<p>Sent test: ", test_tag, "</p><pre>", test_meta, "</pre>"),
     to = "al@newgraphenvironment.com",
     subject = paste("Sent", test_tag),
     draft = FALSE,
@@ -46,7 +76,7 @@ test_that("mc_send sends to self", {
   Sys.sleep(5)
 
   results <- gmailr::gm_messages(
-    search = paste0("subject:\"Sent ", test_tag, "\" in:sent"),
+    search = paste0("subject:", test_tag, " in:sent"),
     num_results = 1
   )
   ids <- gmailr::gm_id(results)
@@ -59,7 +89,7 @@ test_that("mc_send sends to self", {
 
 test_that("mc_thread_find locates the test thread", {
   thread_id <- env$test_thread_id
-  results <- mc_thread_find(paste("subject:\"Sent", test_tag, "\""))
+  results <- mc_thread_find(paste0("subject:", test_tag))
   expect_true(nrow(results) > 0, info = "Thread not found by mc_thread_find")
   expect_true(thread_id %in% results$thread_id)
 })
@@ -68,7 +98,7 @@ test_that("mc_thread_read returns the test message", {
   thread_id <- env$test_thread_id
   thread <- mc_thread_read(thread_id)
   expect_true(nrow(thread) > 0, info = "No messages in thread")
-  expect_true(any(grepl(test_tag, thread$subject)))
+  expect_true(any(grepl(test_tag, thread$subject, fixed = TRUE)))
 })
 
 test_that("mc_send replies into the test thread", {
@@ -76,7 +106,7 @@ test_that("mc_send replies into the test thread", {
 
   # Can't use test = TRUE here — it strips thread_id
   mc_send(
-    html = paste0("<p>Reply test: ", test_tag, "</p>"),
+    html = paste0("<p>Reply test: ", test_tag, "</p><pre>", test_meta, "</pre>"),
     to = "al@newgraphenvironment.com",
     subject = paste("Re: Sent", test_tag),
     thread_id = thread_id,
@@ -102,7 +132,7 @@ test_that("mc_compose with mc_scroll sends a table email", {
   )
 
   body <- mc_compose(
-    paste0("<p>Table test: ", test_tag, "</p>"),
+    paste0("<p>Table test: ", test_tag, "</p><pre>", test_meta, "</pre>"),
     mc_scroll(knitr::kable(df, format = "html"), direction = "both"),
     sig = FALSE
   )
@@ -119,7 +149,7 @@ test_that("mc_compose with mc_scroll sends a table email", {
   Sys.sleep(5)
 
   results <- gmailr::gm_messages(
-    search = paste0("subject:\"Table ", test_tag, "\""),
+    search = paste0("subject:", test_tag),
     num_results = 1
   )
   ids <- gmailr::gm_id(results)

--- a/tests/testthat/test-integration.R
+++ b/tests/testthat/test-integration.R
@@ -29,16 +29,29 @@ test_meta <- sprintf(
 
 env <- new.env(parent = emptyenv())
 
-# Trash all test messages after the run (sent-to-self creates duplicate IDs)
+# Trash test messages after the run.
+# Safeguards against trashing unrelated mail:
+#   1. newer_than:1h — only messages from the last hour
+#   2. Subject verified — each message's subject must contain the exact test_tag
+#      (Gmail search is fuzzy/tokenized; this confirms the match)
+#   3. test_tag includes timestamp to the second — collisions near-impossible
 withr::defer({
   Sys.sleep(5)
   for (label in c("", " in:sent", " in:drafts", " in:inbox")) {
     results <- gmailr::gm_messages(
-      search = paste0("subject:", test_tag, label),
+      search = paste0("subject:", test_tag, " newer_than:1h", label),
       num_results = 20
     )
     for (id in gmailr::gm_id(results)) {
-      tryCatch(gmailr::gm_trash_message(id), error = function(e) NULL)
+      tryCatch({
+        msg <- gmailr::gm_message(id)
+        subj <- msg$payload$headers |>
+          vapply(\(h) if (h$name == "Subject") h$value else NA_character_, character(1))
+        subj <- subj[!is.na(subj)][1]
+        if (!is.na(subj) && grepl(test_tag, subj, fixed = TRUE)) {
+          gmailr::gm_trash_message(id)
+        }
+      }, error = function(e) NULL)
     }
   }
 }, envir = parent.frame())


### PR DESCRIPTION
## Summary

- Require `MC_RUN_INTEGRATION=true` env var to run integration tests (no more accidental inbox spam from `devtools::test()`)
- Stamp email bodies with package version, R version, and OS for traceability
- Auto-trash all test emails via Gmail API after each run
- Harden cleanup with subject verification and `newer_than:1h` time bound

## Test plan

- [x] Unit tests pass (117 pass, integration skipped)
- [x] Integration tests pass (8 pass) with `MC_RUN_INTEGRATION=true`
- [x] Verified 0 test emails escape cleanup
- [x] `lintr::lint_package()` clean

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)