### PR TITLE
mc_preview() accepts .md path with frontmatter header (#25)

### DIFF
--- a/R/mc_preview.R
+++ b/R/mc_preview.R
@@ -1,12 +1,18 @@
 #' Preview composed HTML in a browser before sending
 #'
-#' Writes the output of [mc_compose()] (or any HTML string) to a temp file
-#' and opens it in the default browser. Catches markdown rendering issues
-#' (mis-nested links, stray backticks, unintended list formatting, signature
-#' layout) locally before creating a Gmail draft.
+#' Writes composed HTML to a local file and opens it in the default browser
+#' so markdown rendering issues (mis-nested links, stray backticks,
+#' unintended list formatting, signature layout) can be caught before
+#' creating a Gmail draft.
 #'
-#' @param html A character string containing HTML, typically from
-#'   [mc_compose()].
+#' Accepts either a raw HTML string or a path to a `.md` draft. When a
+#' `.md` path is passed, the frontmatter envelope (To / Cc / Subject /
+#' Thread / Attachments) is rendered above the body so recipient or
+#' subject mistakes are visible too.
+#'
+#' @param html Either a character string of HTML (e.g. from [mc_compose()])
+#'   or a path to a `.md` draft file. A `.md` path is detected by the
+#'   combination of `endsWith(x, ".md")` and `file.exists(x)`.
 #' @param path File path to write the preview to. Defaults to a stable
 #'   location under [tools::R_user_dir()] (`mc/cache/preview.html`) so the
 #'   file persists after the R session exits and can be opened manually.
@@ -17,8 +23,12 @@
 #'
 #' @examples
 #' \dontrun{
+#' # From raw HTML
 #' html <- mc_compose("communications/project/draft.md")
 #' mc_preview(html)
+#'
+#' # Directly from a frontmattered .md — shows envelope above body
+#' mc_preview("communications/20260413_cindy_newsletter_draft.md")
 #' }
 #'
 #' @importFrom chk chk_string chk_flag
@@ -33,8 +43,69 @@ mc_preview <- function(html,
   chk::chk_string(path)
   chk::chk_flag(open)
 
+  if (endsWith(html, ".md") && file.exists(html)) {
+    meta <- mc_md_meta(html)
+    body <- mc_md_render(html)
+    html <- paste0(preview_header(meta), body)
+  }
+
   dir.create(dirname(path), showWarnings = FALSE, recursive = TRUE)
   writeLines(html, path)
   if (open) utils::browseURL(path)
   invisible(path)
+}
+
+
+#' Build an HTML header table from frontmatter metadata
+#'
+#' Renders To / Cc / Bcc (if present) / Subject / Thread / Attachments as
+#' a simple inline-styled table above the preview body.
+#' @param meta Named list from [mc_md_meta()].
+#' @return HTML string.
+#' @noRd
+preview_header <- function(meta) {
+  dash <- "\u2014"
+  fmt <- function(x) {
+    if (is.null(x) || length(x) == 0) return(dash)
+    paste(as.character(x), collapse = ", ")
+  }
+  rows <- list(
+    c("To", fmt(meta$to)),
+    c("Cc", fmt(meta$cc))
+  )
+  if (!is.null(meta$bcc)) rows[[length(rows) + 1]] <- c("Bcc", fmt(meta$bcc))
+  rows <- c(rows, list(
+    c("Subject", fmt(meta$subject)),
+    c("Thread", fmt(meta$thread_id)),
+    c("Attach", fmt(meta$attachments))
+  ))
+  row_html <- vapply(rows, function(r) {
+    sprintf(
+      paste0(
+        '<tr>',
+        '<th style="text-align:left; padding:4px 12px 4px 0; ',
+        'color:#555; white-space:nowrap;">%s</th>',
+        '<td style="padding:4px 0;">%s</td>',
+        '</tr>'
+      ),
+      r[1], htmlEscape(r[2])
+    )
+  }, character(1))
+  paste0(
+    '<table style="border-collapse:collapse; margin-bottom:16px; ',
+    'padding-bottom:12px; border-bottom:1px solid #ddd; ',
+    'font-family:sans-serif; font-size:13px;">',
+    paste(row_html, collapse = ""),
+    '</table>'
+  )
+}
+
+
+#' Minimal HTML escaping for preview header values
+#' @noRd
+htmlEscape <- function(x) {  # nolint: object_name_linter
+  x <- gsub("&", "&amp;", x, fixed = TRUE)
+  x <- gsub("<", "&lt;", x, fixed = TRUE)
+  x <- gsub(">", "&gt;", x, fixed = TRUE)
+  x
 }

--- a/man/mc_preview.Rd
+++ b/man/mc_preview.Rd
@@ -11,8 +11,9 @@ mc_preview(
 )
 }
 \arguments{
-\item{html}{A character string containing HTML, typically from
-\code{\link[=mc_compose]{mc_compose()}}.}
+\item{html}{Either a character string of HTML (e.g. from \code{\link[=mc_compose]{mc_compose()}})
+or a path to a \code{.md} draft file. A \code{.md} path is detected by the
+combination of \code{endsWith(x, ".md")} and \code{file.exists(x)}.}
 
 \item{path}{File path to write the preview to. Defaults to a stable
 location under \code{\link[tools:userdir]{tools::R_user_dir()}} (\code{mc/cache/preview.html}) so the
@@ -25,15 +26,25 @@ file persists after the R session exits and can be opened manually.}
 The file path, invisibly.
 }
 \description{
-Writes the output of \code{\link[=mc_compose]{mc_compose()}} (or any HTML string) to a temp file
-and opens it in the default browser. Catches markdown rendering issues
-(mis-nested links, stray backticks, unintended list formatting, signature
-layout) locally before creating a Gmail draft.
+Writes composed HTML to a local file and opens it in the default browser
+so markdown rendering issues (mis-nested links, stray backticks,
+unintended list formatting, signature layout) can be caught before
+creating a Gmail draft.
+}
+\details{
+Accepts either a raw HTML string or a path to a \code{.md} draft. When a
+\code{.md} path is passed, the frontmatter envelope (To / Cc / Subject /
+Thread / Attachments) is rendered above the body so recipient or
+subject mistakes are visible too.
 }
 \examples{
 \dontrun{
+# From raw HTML
 html <- mc_compose("communications/project/draft.md")
 mc_preview(html)
+
+# Directly from a frontmattered .md — shows envelope above body
+mc_preview("communications/20260413_cindy_newsletter_draft.md")
 }
 
 }

--- a/tests/testthat/test-mc_preview.R
+++ b/tests/testthat/test-mc_preview.R
@@ -26,6 +26,59 @@ test_that("mc_preview calls browseURL when open=TRUE", {
   expect_equal(called, path)
 })
 
+test_that("mc_preview renders frontmatter header when given .md path", {
+  draft <- tempfile(fileext = ".md")
+  writeLines(c(
+    "---",
+    "to: cindy@x.com",
+    "cc: [a@x.com, b@x.com]",
+    "subject: Newsletter draft",
+    "thread_id: t1",
+    "attachments: [/tmp/x.pdf]",
+    "---",
+    "Hi Cindy,",
+    "",
+    "Body here."
+  ), draft)
+  tmp <- tempfile(fileext = ".html")
+  mc_preview(draft, path = tmp, open = FALSE)
+  html <- paste(readLines(tmp), collapse = "\n")
+  expect_true(grepl("cindy@x.com", html))
+  expect_true(grepl("a@x.com, b@x.com", html))
+  expect_true(grepl("Newsletter draft", html))
+  expect_true(grepl("t1", html))
+  expect_true(grepl("/tmp/x.pdf", html))
+  expect_true(grepl("Body here", html))
+})
+
+test_that("mc_preview .md path without frontmatter still renders body", {
+  draft <- tempfile(fileext = ".md")
+  writeLines(c("Just a body", "no frontmatter here"), draft)
+  tmp <- tempfile(fileext = ".html")
+  mc_preview(draft, path = tmp, open = FALSE)
+  html <- paste(readLines(tmp), collapse = "\n")
+  # empty frontmatter renders em-dash in required rows
+  expect_true(grepl("Subject", html))
+  expect_true(grepl("\u2014", html))
+  expect_true(grepl("Just a body", html))
+})
+
+test_that("mc_preview .md path escapes HTML in frontmatter values", {
+  draft <- tempfile(fileext = ".md")
+  writeLines(c(
+    "---",
+    "to: a@x.com",
+    "subject: \"<script>alert(1)</script>\"",
+    "---",
+    "body"
+  ), draft)
+  tmp <- tempfile(fileext = ".html")
+  mc_preview(draft, path = tmp, open = FALSE)
+  html <- paste(readLines(tmp), collapse = "\n")
+  expect_true(grepl("&lt;script&gt;", html))
+  expect_false(grepl("<script>alert", html))
+})
+
 test_that("mc_preview default path is under R_user_dir and persists", {
   cache_root <- tempfile()
   withr::with_envvar(c(R_USER_CACHE_DIR = cache_root), {


### PR DESCRIPTION
## Summary

- `mc_preview()` now accepts a `.md` path in addition to an HTML string
- When a path is passed, the frontmatter envelope (To / Cc / Subject / Thread / Attach) is rendered as an inline-styled table above the body so recipient or subject mistakes are visible before drafting to Gmail
- Empty fields render as em-dashes; values are HTML-escaped

## Test plan

- [x] `devtools::test()` — 239 pass, 0 fail, 1 skip
- [x] `lintr` clean on touched files
- [x] `/code-check` — clean first round
- [ ] Manual: `mc_preview("communications/some_draft.md")` on a real frontmattered draft

Fixes #25

Relates to NewGraphEnvironment/sred-2025-2026#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
